### PR TITLE
pdf2kindle improvement

### DIFF
--- a/bin/bin/pdf2kindle-native
+++ b/bin/bin/pdf2kindle-native
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo | k2pdfopt -dev kpw -mode fw -ppgs "$1"

--- a/bin/pdf2kindle
+++ b/bin/pdf2kindle
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-echo | k2pdfopt -dev kpw -bp -f2p 0 -odpi 300 "$1"
+echo | k2pdfopt -dev kpw -ac -as -bp -f2p 0 -odpi 300 -ppgs "$1"
+# for PaperWhite 2 use -dev kp2

--- a/bin/pdf2kindle-sci
+++ b/bin/pdf2kindle-sci
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-echo | k2pdfopt -dev kpw -mode 2col "$1"
+echo | k2pdfopt -dev kpw -mode 2col -ppgs "$1"


### PR DESCRIPTION
A new auto-cropping feature (-ac) has been added where k2pdfopt will attempt to crop out dark edges due to scanning / copying artifacts

-as option will attempt to automatically straighten source pages (if tilted scan)

-ppgs option to post process output with ghostscript pdfwrite device.  This can improve text selection when there are overlapping cropped regions
